### PR TITLE
install nestjs/cli in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,6 +6,8 @@ COPY package*.json ./
 
 ENV NODE_ENV production
 
+RUN npm i -g @nestjs/cli
+
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
there's an error in docker build that requires nestjs/cli install